### PR TITLE
Better Non-running Tests

### DIFF
--- a/test/mixins/xdefine.scss
+++ b/test/mixins/xdefine.scss
@@ -1,11 +1,15 @@
+$test: true;
+
 @include xdefine("xDefine") {
   @include it("shouldnt run") {
-    @include should(null, false);
+    $test: false;
+    @include should(null, $test);
   }
 
   @include define("normal submodule") {
     @include it("shouldnt run sub-modules") {
-      @include should(null, false);
+      $test: false;
+      @include should(null, $test);
     }
   }
 }
@@ -13,11 +17,12 @@
 @include define("xDefine") {
   @include xdefine("Submodule") {
     @include it("shouldnt run sub-modules") {
-      @include should(null, false);
+      $test: false;
+      @include should(null, $test);
     }
   }
 
   @include it("should run after xdefined sub-modules") {
-    @include should(null, true);
+    @include should(null, $test);
   }
 }

--- a/test/mixins/xit.scss
+++ b/test/mixins/xit.scss
@@ -1,9 +1,12 @@
+$test: true;
+
 @include define("xIt") {
   @include xit("shouldnt run a test") {
-    @include should(null, false);
+    $test: false;
+    @include should(null, $test);
   }
 
   @include it("should run a later test") {
-    @include should(null, true);
+    @include should(null, $test);
   }
 }


### PR DESCRIPTION
- Affects `xdefine` and `xit` tests
- Adds `$test` variable to track if tests, that weren't supposed to run, did run.
