### PR TITLE
Remove Markdown specific trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,3 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.md]
-trim_trailing_whitespace = false


### PR DESCRIPTION
- Affects `editorconfig`
- Removes markdown-specific `trim_trailing_whitespace = false`
