### PR TITLE
Add Utils and Clean Up

### DIFF
--- a/dist/_bootcamp.scss
+++ b/dist/_bootcamp.scss
@@ -18,6 +18,8 @@
 @import "core/functions/should";
 @import "core/functions/to";
 
+@import "utils/contain";
+@import "utils/equal";
 @import "utils/power";
 @import "utils/stringify";
 

--- a/dist/core/functions/_expect.scss
+++ b/dist/core/functions/_expect.scss
@@ -1,5 +1,6 @@
 @function expect($this) {
   $bootcamp-should-a-text: "Expected";
   $bootcamp-should-a-value: $this;
+
   @return null;
 }

--- a/dist/core/functions/_not-to.scss
+++ b/dist/core/functions/_not-to.scss
@@ -1,4 +1,5 @@
 @function not-to($this) {
   $bootcamp-should-b-text: "not to " + $bootcamp-should-b-text;
+
   @return not $this;
 }

--- a/dist/core/functions/_should.scss
+++ b/dist/core/functions/_should.scss
@@ -1,5 +1,6 @@
 @function should($be, $something, $when) {
   $bootcamp-should-b-text: $be;
   $bootcamp-should-b-value: $something;
+
   @return $when;
 }

--- a/dist/core/functions/_to.scss
+++ b/dist/core/functions/_to.scss
@@ -1,4 +1,5 @@
 @function to($this) {
   $bootcamp-should-b-text: "to " + $bootcamp-should-b-text;
+
   @return $this;
 }

--- a/dist/core/mixins/_xdescribe.scss
+++ b/dist/core/mixins/_xdescribe.scss
@@ -1,11 +1,9 @@
-///
-// xDescribe
-///
-
 @mixin xdescribe($bootcamp-canceled) {
   $bootcamp-skipping: true;
+
   @include describe($bootcamp-canceled) {
     @content;
   }
+
   $bootcamp-skipping: false;
 }

--- a/dist/core/mixins/_xit.scss
+++ b/dist/core/mixins/_xit.scss
@@ -1,7 +1,9 @@
 @mixin xit($bootcamp-canceled) {
   $bootcamp-skipping: true;
+
   @include it($bootcamp-canceled) {
     @content;
   }
+
   $bootcamp-skipping: false;
 }

--- a/dist/matchers/_be.scss
+++ b/dist/matchers/_be.scss
@@ -1,3 +1,3 @@
-@function be($this) {
-  @return should("be", $this, actual() == $this);
+@function be($value) {
+  @return should("be", $value, bootcamp-util-equal( actual(), $value ) );
 }

--- a/dist/matchers/_equal.scss
+++ b/dist/matchers/_equal.scss
@@ -1,12 +1,3 @@
-@function equal($list) {
-  $actual: actual();
-  $when: true;
-
-  @for $i from 1 through length($list) {
-    @if length($actual) >= $i and nth($actual, $i) != nth($list, $i) {
-      $when: false;
-    }
-  }
-
-  @return should("equal", $list, $when);
+@function equal($value) {
+  @return should("equal", $value, actual() == $value);
 }

--- a/dist/matchers/lists/_contain.scss
+++ b/dist/matchers/lists/_contain.scss
@@ -1,3 +1,3 @@
-@function contain($this) {
-  @return should("contain", $this, not not index(actual(), $this));
+@function contain($value) {
+  @return should("deep contain", $value, bootcamp-util-contain( actual(), $value ));
 }

--- a/dist/matchers/lists/_deep-contain.scss
+++ b/dist/matchers/lists/_deep-contain.scss
@@ -1,26 +1,3 @@
-@function deep-contain($list) {
-  $flattened: actual();
-  $contains-list: true;
-
-  @while $contains-list {
-    $contains-list: false;
-    $temp: $flattened;
-    $flattened: ();
-
-    @each $item in $temp {
-      @if type-of($item) == "list" {
-        @each $_item in $item {
-          @if type-of($_item) == "list" and not $shallow {
-            $contains-list: true;
-          }
-
-          $flattened: append($flattened, $_item, comma);
-        }
-      } @else {
-        $flattened: append($flattened, $item, comma);
-      }
-    }
-  }
-
-  @return should("deep contain", $list, not not index($flattened, $list));
+@function deep-contain($value) {
+  @return should("deep contain", $value, bootcamp-util-contain( actual(), $value, $recursive: true ));
 }

--- a/dist/matchers/lists/_deep-equal.scss
+++ b/dist/matchers/lists/_deep-equal.scss
@@ -41,5 +41,7 @@
     }
   }
 
+  $throw: error("dep", "The `deep-equal` matcher has been deprecated, please use the `be` matcher for the same functionality");
+
   @return should("deep equal", $expected, $when);
 }

--- a/dist/utils/_contain.scss
+++ b/dist/utils/_contain.scss
@@ -1,0 +1,15 @@
+@function bootcamp-util-contain($list, $value, $recursive: false) {
+  @each $item in $list {
+    @if type-of( $item ) == list and $recursive {
+      @if bootcamp-util-contain($item, $value, $recursive) {
+        @return true;
+      }
+    }
+
+    @if $item == $value {
+      @return true;
+    }
+  }
+
+  @return false;
+}

--- a/dist/utils/_equal.scss
+++ b/dist/utils/_equal.scss
@@ -1,0 +1,23 @@
+@function bootcamp-util-equal($value-1, $value-2, $recursive: true) {
+  @if length($value-1) != length($value-2) {
+    @return false;
+  }
+
+  @for $i from 1 through length($value-1) {
+
+    @if $recursive
+    and type-of( nth($value-1, $i) ) == list
+    and type-of( nth($value-2, $i) ) == list {
+
+      @if not bootcamp-util-equal(nth($value-1, $i), nth($value-2, $i)) {
+        @return false;
+      }
+    }
+
+    @else if nth($value-1, $i) != nth($value-2, $i){
+      @return false;
+    }
+  }
+
+  @return true;
+}

--- a/test/_specs.scss
+++ b/test/_specs.scss
@@ -17,6 +17,8 @@ $bootcamp-setting-warnings: false;
 @import "core/functions/should";
 @import "core/functions/to";
 
+@import "utils/contain";
+@import "utils/equal";
 @import "utils/power";
 @import "utils/stringify";
 

--- a/test/matchers/_be.scss
+++ b/test/matchers/_be.scss
@@ -14,4 +14,77 @@
     @include should( expect( false     ), not-to( be( true    )));
     @include should( expect( null      ), not-to( be( valid   )));
   }
+
+  @include it("should expect two equal values to be equal") {
+    @include should( expect(  1    ), to( be(  1    )));
+    @include should( expect( -1    ), to( be( -1    )));
+    @include should( expect( a     ), to( be( a     )));
+    @include should( expect( false ), to( be( false )));
+  }
+
+  @include it("should expect two non-equal values not to be equal") {
+    @include should( expect(  1    ), not-to( be( 2    )));
+    @include should( expect( -1    ), not-to( be( 1    )));
+    @include should( expect( a     ), not-to( be( b    )));
+    @include should( expect( false ), not-to( be( true )));
+  }
+
+  @include it("should expect two equal lists to be equal") {
+    @include should(expect( (1, 2, 3) ),           to( be( (1, 2, 3) )));
+    @include should(expect( ("a", "b", "c") ),     to( be( ("a", "b", "c") )));
+    @include should(expect( (true, false, true) ), to( be( (true, false, true) )));
+  }
+
+  @include it("should expect two unequal lists not to be equal") {
+    @include should(expect( (3, 2, 1) ),            not-to( be( (1, 2, 3) )));
+    @include should(expect( ("c", "b", "a") ),      not-to( be( ("a", "b", "c") )));
+    @include should(expect( (false, true, false) ), not-to( be( (true, false, true) )));
+  }
+
+  @include it("should expect two equal lists with different seperators to be equal") {
+    @include should(expect( 1 2 3 ),           to( be( (1, 2, 3) )));
+    @include should(expect( "a" "b" "c" ),     to( be( ("a", "b", "c") )));
+    @include should(expect( true false true ), to( be( (true, false, true) )));
+  }
+
+  @include it("should expect two equal lists built up programmatically to be equal") {
+    $numbers: 1, 2, 3;
+    $strings: "a", "b", "c";
+    $booleans: true, false, true;
+
+    $numbers-out:  ();
+    $strings-out:  ();
+    $booleans-out: ();
+
+    @for $i from 1 through 3 {
+      $numbers-out:  append($numbers-out,  nth($numbers,  $i), comma);
+      $strings-out:  append($strings-out,  nth($strings,  $i), comma);
+      $booleans-out: append($booleans-out, nth($booleans, $i), comma);
+    }
+
+    @include should(expect($numbers-out ), to( be( (1, 2, 3) )));
+    @include should(expect($strings-out ), to( be( ("a", "b", "c") )));
+    @include should(expect($booleans-out), to( be( (true, false, true) )));
+  }
+
+  @include it("should expect two unequal lists built up programmatically not to be equal") {
+    $numbers: 1, 2, 3;
+    $strings: "a", "b", "c";
+    $booleans: true, false, true;
+
+    $numbers-out:  ();
+    $strings-out:  ();
+    $booleans-out: ();
+
+    @for $i from 1 through 3 {
+      $numbers-out:  append($numbers-out,  nth($numbers,  $i), comma);
+      $strings-out:  append($strings-out,  nth($strings,  $i), comma);
+      $booleans-out: append($booleans-out, nth($booleans, $i), comma);
+    }
+
+    @include should(expect($numbers-out ), not-to( be( (3, 2, 1) )));
+    @include should(expect($strings-out ), not-to( be( ("c", "b", "a") )));
+    @include should(expect($booleans-out), not-to( be( (false, true, false) )));
+  }
 }
+

--- a/test/matchers/_equal.scss
+++ b/test/matchers/_equal.scss
@@ -25,49 +25,9 @@
     @include should(expect( (false, true, false) ), not-to( equal( (true, false, true) )));
   }
 
-  @include it("should expect two equal lists with different seperators to be equal") {
-    @include should(expect( 1 2 3 ),           to( equal( (1, 2, 3) )));
-    @include should(expect( "a" "b" "c" ),     to( equal( ("a", "b", "c") )));
-    @include should(expect( true false true ), to( equal( (true, false, true) )));
-  }
-
-  @include it("should expect two equal lists built up programmatically to be equal") {
-    $numbers: 1, 2, 3;
-    $strings: "a", "b", "c";
-    $booleans: true, false, true;
-
-    $numbers-out:  ();
-    $strings-out:  ();
-    $booleans-out: ();
-
-    @for $i from 1 through 3 {
-      $numbers-out:  append($numbers-out,  nth($numbers,  $i));
-      $strings-out:  append($strings-out,  nth($strings,  $i));
-      $booleans-out: append($booleans-out, nth($booleans, $i));
-    }
-
-    @include should(expect($numbers-out ), to( equal( (1, 2, 3) )));
-    @include should(expect($strings-out ), to( equal( ("a", "b", "c") )));
-    @include should(expect($booleans-out), to( equal( (true, false, true) )));
-  }
-
-  @include it("should expect two unequal lists built up programmatically not to be equal") {
-    $numbers: 1, 2, 3;
-    $strings: "a", "b", "c";
-    $booleans: true, false, true;
-
-    $numbers-out:  ();
-    $strings-out:  ();
-    $booleans-out: ();
-
-    @for $i from 1 through 3 {
-      $numbers-out:  append($numbers-out,  nth($numbers,  $i));
-      $strings-out:  append($strings-out,  nth($strings,  $i));
-      $booleans-out: append($booleans-out, nth($booleans, $i));
-    }
-
-    @include should(expect($numbers-out ), not-to( equal( (3, 2, 1) )));
-    @include should(expect($strings-out ), not-to( equal( ("c", "b", "a") )));
-    @include should(expect($booleans-out), not-to( equal( (false, true, false) )));
+  @include it("should expect two equal lists with different seperators not to be equal") {
+    @include should(expect( 1 2 3 ),           not-to( equal( (1, 2, 3) )));
+    @include should(expect( "a" "b" "c" ),     not-to( equal( ("a", "b", "c") )));
+    @include should(expect( true false true ), not-to( equal( (true, false, true) )));
   }
 }

--- a/test/utils/_contain.scss
+++ b/test/utils/_contain.scss
@@ -1,0 +1,41 @@
+@include describe("Contain Util") {
+  @include it("should return true for lists that contain a value") {
+    $list-1: 1, 2, 3;
+    $list-2: "foo", "bar", "baz";
+    $list-3: true, false, true;
+
+    @include should(expect( bootcamp-util-contain( $list-1, 2     ) ), to( be( true )));
+    @include should(expect( bootcamp-util-contain( $list-2, "bar" ) ), to( be( true )));
+    @include should(expect( bootcamp-util-contain( $list-3, false ) ), to( be( true )));
+  }
+
+  @include it("should return false for lists that do not contain a value") {
+    $list-1: 1, 2, 3;
+    $list-2: "foo", "bar", "baz";
+    $list-3: true, false, true;
+
+    @include should(expect( bootcamp-util-contain( $list-1, 4     ) ), to( be( false )));
+    @include should(expect( bootcamp-util-contain( $list-2, "tah" ) ), to( be( false )));
+    @include should(expect( bootcamp-util-contain( $list-3, null  ) ), to( be( false )));
+  }
+
+  @include it("should return true for lists that deep contain a value") {
+    $list-1: 1, (2, 3);
+    $list-2: "foo", ("bar", "baz");
+    $list-3: true, (false, true);
+
+    @include should(expect( bootcamp-util-contain( $list-1, 2,     $recursive: true ) ), to( be( true )));
+    @include should(expect( bootcamp-util-contain( $list-2, "bar", $recursive: true ) ), to( be( true )));
+    @include should(expect( bootcamp-util-contain( $list-3, false, $recursive: true ) ), to( be( true )));
+  }
+
+  @include it("should return false for lists that do not deep contain a value") {
+    $list-1: 1, (2, 3);
+    $list-2: "foo", ("bar", "baz");
+    $list-3: true, (false, true);
+
+    @include should(expect( bootcamp-util-contain( $list-1, 4,     $recursive: true ) ), to( be( false )));
+    @include should(expect( bootcamp-util-contain( $list-2, "tah", $recursive: true ) ), to( be( false )));
+    @include should(expect( bootcamp-util-contain( $list-3, null,  $recursive: true ) ), to( be( false )));
+  }
+}

--- a/test/utils/_equal.scss
+++ b/test/utils/_equal.scss
@@ -1,0 +1,79 @@
+@include describe("Equal Util") {
+  @include it("should return true for lists that are equal") {
+    $list-1: 1, 2, 3;
+    $list-2: "foo", "bar", "baz";
+    $list-3: true, false, true;
+
+    @include should(expect( bootcamp-util-equal( $list-1, $list-1 ) ), to( be( true )));
+    @include should(expect( bootcamp-util-equal( $list-2, $list-2 ) ), to( be( true )));
+    @include should(expect( bootcamp-util-equal( $list-3, $list-3 ) ), to( be( true )));
+  }
+
+  @include it("should return false for lists that are not equal") {
+    $list-1a: 1, 2, 3;
+    $list-1b: 3, 2, 1;
+
+    $list-2a: "foo", "bar", "baz";
+    $list-2b: "baz", "bar", "foo";
+
+    $list-3a: true, false, true;
+    $list-3b: false, true, false;
+
+    @include should(expect( bootcamp-util-equal( $list-1a, $list-1b ) ), to( be( false )));
+    @include should(expect( bootcamp-util-equal( $list-2a, $list-2b ) ), to( be( false )));
+    @include should(expect( bootcamp-util-equal( $list-3a, $list-3b ) ), to( be( false )));
+  }
+
+  @include it("should return true for deep lists that are equal") {
+    $list-1: 1, (2, 3);
+    $list-2: "foo", ("bar", "baz");
+    $list-3: true, (false, true);
+
+    @include should(expect( bootcamp-util-equal( $list-1, $list-1 ) ), to( be( true )));
+    @include should(expect( bootcamp-util-equal( $list-2, $list-2 ) ), to( be( true )));
+    @include should(expect( bootcamp-util-equal( $list-3, $list-3 ) ), to( be( true )));
+  }
+
+  @include it("should return false for deep lists that are not equal") {
+    $list-1a: 1, (2, 3);
+    $list-1b: 1, (3, 2);
+
+    $list-2a: "foo", ("bar", "baz");
+    $list-2b: "foo", ("baz", "bar");
+
+    $list-3a: true, (false, true);
+    $list-3b: true, (true, false);
+
+    @include should(expect( bootcamp-util-equal( $list-1a, $list-1b ) ), to( be( false )));
+    @include should(expect( bootcamp-util-equal( $list-2a, $list-2b ) ), to( be( false )));
+    @include should(expect( bootcamp-util-equal( $list-3a, $list-3b ) ), to( be( false )));
+  }
+
+  @include it("should return true for lists that are equal and have different list seperators") {
+    $list-1a: 1 2 3;
+    $list-1b: 1, 2, 3;
+    $list-2a: "foo" "bar" "baz";
+    $list-2b: "foo", "bar", "baz";
+    $list-3a: true false true;
+    $list-3b: true, false, true;
+
+    @include should(expect( bootcamp-util-equal( $list-1a, $list-1b ) ), to( be( true )));
+    @include should(expect( bootcamp-util-equal( $list-2a, $list-2b ) ), to( be( true )));
+    @include should(expect( bootcamp-util-equal( $list-3a, $list-3b ) ), to( be( true )));
+  }
+
+  @include it("should return false for lists that are not equal and have different list seperators") {
+    $list-1a: 1 2 3;
+    $list-1b: 3, 2, 1;
+
+    $list-2a: "foo" "bar" "baz";
+    $list-2b: "baz", "bar", "foo";
+
+    $list-3a: true false true;
+    $list-3b: false, true, false;
+
+    @include should(expect( bootcamp-util-equal( $list-1a, $list-1b ) ), to( be( false )));
+    @include should(expect( bootcamp-util-equal( $list-2a, $list-2b ) ), to( be( false )));
+    @include should(expect( bootcamp-util-equal( $list-3a, $list-3b ) ), to( be( false )));
+  }
+}


### PR DESCRIPTION
- Adds Contain util
- Adds Equal util
- Deprecates `deep-contain`
- switches meanings of `be` and `equal` matchers
- Fixes some whitespace
- Renames some variables
