### PR TITLE
Change warning to failure in the Grunt task, if the tests failed...

### DIFF
--- a/tasks/bootcamp.coffee
+++ b/tasks/bootcamp.coffee
@@ -61,7 +61,7 @@ module.exports = (grunt) ->
       hasFailed: ->
         @logSpecs()
         @logStats()
-        @warn @tests.details
+        @fail @tests.details
         @logErrors()
         return false
 


### PR DESCRIPTION
...so that the the overall Grunt execution fails. This is useful for when the Grunt task is used as part of a CI build (such as using TravisCI) where failed tests should cause the build to be labelled as a failure.
