### PR TITLE
fixes

### DIFF
--- a/dist/core/mixins/_it.scss
+++ b/dist/core/mixins/_it.scss
@@ -1,3 +1,4 @@
+@charset "utf-8";
 @mixin it($statement) {
   $bc-total: $bc-total + 1 !global;
 

--- a/dist/core/mixins/_should.scss
+++ b/dist/core/mixins/_should.scss
@@ -1,3 +1,4 @@
+@charset "utf-8";
 @mixin should($actual, $expect) {
   @if $bc-error {
     $expect: false !global;


### PR DESCRIPTION
Error: Invalid US-ASCII character "\xE2"
        on line 15 of /Users/mmintel/Opensource/core/bower_components/bootcamp/dist/core/mixins/_it.scss
        from line 10 of /Users/mmintel/Opensource/core/bower_components/bootcamp/dist/_bootcamp.scss
        from line 2 of tests/tests.scss
  Use --trace for backtrace.

  and

  Error: Invalid US-ASCII character "\xE2"
          on line 16 of /Users/mmintel/Opensource/core/bower_components/bootcamp/dist/core/mixins/_should.scss
          from line 12 of /Users/mmintel/Opensource/core/bower_components/bootcamp/dist/_bootcamp.scss
          from line 2 of tests/tests.scss
    Use --trace for backtrace.
