### PR TITLE
upadte grunt peerDependecies to ">=0.4.5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-contrib-watch": "^0.6.1"
   },
   "peerDependencies": {
-    "grunt": "^0.4.5",
+    "grunt": ">=0.4.5",
     "grunt-contrib-sass": "^0.8.0"
   },
   "engines": {


### PR DESCRIPTION
Allow projects that uses grunt 1.0 in other grunt plugins to use this plugin as well
